### PR TITLE
Now, works with Octave 8.2.0 and added a few more 2d examples.

### DIFF
--- a/demo/demo_regression_2d.m
+++ b/demo/demo_regression_2d.m
@@ -37,3 +37,5 @@ yt = kaf.evaluate([x1(:) x2(:)]);
 z = reshape(yt,size(x1,1),size(x2,1));
 figure;
 surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");  # adding the training data

--- a/demo/demo_regression_2d_exkrls.m
+++ b/demo/demo_regression_2d_exkrls.m
@@ -1,0 +1,92 @@
+% Showcasing Extended kernel RLS
+%
+% "Problem" with this implementation is that is does not update anymore
+% once number of presented data points exceed M.
+
+close all
+clear
+
+%% PARAMETERS
+
+algorithm = 'exkrls'; % algorithm class (choose from lib/ folder)
+opts = struct(
+  "alphaf", .999, % state forgetting factor, "alpha" in publication
+  "beta", .995, % data forgetting factor
+  "lambda", 1E-2, % regularization parameter
+  "q", 1E-3, % trade-off between modeling variation and measurement disturbance
+  "M", 100,  # dictionary size  # not necessarily the lookback
+  # "kerneltype", 'gauss'
+  "kerneltype", 'linear'  # can only fit a plane
+
+); % algorithm options go here (kernel type, parameters, etc)
+
+%% PROGRAM
+
+kaf = feval(algorithm, opts); %#ok<FVAL>
+
+% generate some data
+c = 5;
+N = 200;
+x = rand(N,2)*c;
+y = zeros(N,1);
+% y = sin(3*x(:,1)).*cos(x(:,1)+x(:,2));  # non-linear surface
+y(1:N/2) = 3*x(1:N/2,1)+0.5*x(1:N/2,2);  # linear surface
+y(N/2:N) = -1*x(N/2:N,1)-1.5*x(N/2:N,2);  # linear surface changes
+y = y + randn(N,1)*1.0;  # add some noise
+
+fprintf('First half of Training')
+for i=1:(N/2-1)
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training shortly after Non-Stationarity')
+for i=N/2:N/2+9
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training Rest')
+for i=N/2+10:N
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");

--- a/demo/demo_regression_2d_plane.m
+++ b/demo/demo_regression_2d_plane.m
@@ -1,0 +1,90 @@
+% Linear plane regression demo.
+%
+% This file is part of the Kernel Adaptive Filtering Toolbox for Matlab.
+% https://github.com/steven2358/kafbox
+
+close all
+clear
+
+%% PARAMETERS
+
+algorithm = 'krlst'; % algorithm class (choose from lib/ folder)
+opts = struct(
+  "lambda", 0.9999,  # forgetting factor
+  "M", 10,  # dictionary size  # not necessarily the lookback
+  "sn2", 1E-2,  # noise to signal ratio (regularization parameter)
+  # "kerneltype", 'gauss'
+  "kerneltype", 'linear',  # can only fit a plane
+  "jitter", 1E-6
+); % algorithm options go here (kernel type, parameters, etc)
+
+%% PROGRAM
+
+kaf = feval(algorithm, opts); %#ok<FVAL>
+
+% generate some data
+c = 5;
+N = 200;
+x = rand(N,2)*c;
+y = zeros(N,1);
+% y = sin(3*x(:,1)).*cos(x(:,1)+x(:,2));
+y(1:N/2) = 3*x(1:N/2,1)+0.5*x(1:N/2,2);  # linear surface
+y(N/2:N) = -1*x(N/2:N,1)-1.5*x(N/2:N,2);  # linear surface changes
+y = y + randn(N,1)*1.0;  # add some noise
+
+fprintf('First half of Training')
+for i=1:(N/2-1)
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training after Non-Stationarity')
+for i=N/2:N/2+2
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training Rest')
+for i=N/2+3:N
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");

--- a/demo/demo_regression_2d_swkrls.m
+++ b/demo/demo_regression_2d_swkrls.m
@@ -1,0 +1,87 @@
+% Showcasing sliding window kernel RLS
+
+close all
+clear
+
+%% PARAMETERS
+
+algorithm = 'swkrls'; % algorithm class (choose from lib/ folder)
+opts = struct(
+  "lambda", 0.99999,  # forgetting factor
+  "c", 1E-2, % regularization parameter e.g. with 1E3 we see significant shrinkage
+  "M", 100,  # dictionary size  # not necessarily the lookback
+  # "kerneltype", 'gauss'
+  "kerneltype", 'linear'  # can only fit a plane
+
+); % algorithm options go here (kernel type, parameters, etc)
+
+%% PROGRAM
+
+kaf = feval(algorithm, opts); %#ok<FVAL>
+
+% generate some data
+c = 5;
+N = 200;
+x = rand(N,2)*c;
+y = zeros(N,1);
+% y = sin(3*x(:,1)).*cos(x(:,1)+x(:,2));  # non-linear surface
+y(1:N/2) = 3*x(1:N/2,1)+0.5*x(1:N/2,2);  # linear surface
+y(N/2:N) = -1*x(N/2:N,1)-1.5*x(N/2:N,2);  # linear surface changes
+y = y + randn(N,1)*1.0;  # add some noise
+
+fprintf('First half of Training')
+for i=1:(N/2-1)
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training shortly after Non-Stationarity')
+for i=N/2:N/2+49
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");
+
+fprintf('Training Rest')
+for i=N/2+50:N
+    if ~mod(i,floor(N/10)), fprintf('.'); end
+    kaf.train(x(i,:),y(i));
+    % y_test = kaf.evaluate(x(i+1,:));
+end
+fprintf('\n')
+
+%% OUTPUT
+
+[x1,x2] = meshgrid(0:.2:c, 0:.2:c);
+yt = kaf.evaluate([x1(:) x2(:)]);
+
+z = reshape(yt,size(x1,1),size(x2,1));
+figure;
+surf(x1,x2,z);
+hold;
+plot3(x(:,1), x(:,2), y, "+");

--- a/lib/base/base_estimator.m
+++ b/lib/base/base_estimator.m
@@ -3,13 +3,14 @@
 % This file is part of the Kernel Adaptive Filtering Toolbox for Matlab.
 % https://github.com/steven2358/kafbox/
 
-classdef base_estimator < matlab.mixin.Copyable
+##classdef base_estimator < matlab.mixin.Copyable
+classdef base_estimator < handle
     methods
         % get parameter names for the estimator
         function names = get_param_names(obj)
             names = fieldnames(obj);
         end
-        
+
         % get parameters
         function params = get_params(obj)
             params = struct;
@@ -17,7 +18,7 @@ classdef base_estimator < matlab.mixin.Copyable
                 params.(fn{1}) = obj.(fn{1});
             end
         end
-        
+
         % set parameters
         function set_params(obj,params)
             if (nargin > 0) % copy valid parameters


### PR DESCRIPTION
By replacing matlab.mixin.Copyable with handle it now works with the Octave version 8.2.0.
I added a few more regression examples to visualize the tracking performance.